### PR TITLE
Add csv option and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,27 @@
 
 Dump information from `stacks-node` storage
 
-### Usage
+## Usage
+
+### Default
+
 ```
 node report-pox-krypton.js /tmp/stacks-testnet-5c87e24790411516
 ```
 
-or if `stacks-node` is compiled with `--feature tx-log`, to display transactions for each block:
+### Options
+
+`-t` - display transactions for each block (if `stacks-node) is compiled with `--feature tx-log`
+
 ```
 cargo build --workspace  --features tx_log --bin stacks-node
 
 node report-pox-krypton.js -t /tmp/stacks-testnet-5c87e24790411516
 ```
+
+`-csv` - display transactions in CSV format
+
+```
+node report-pox-krypton.js -csv /tmp/stacks-testnet-5c87e24790411516
+```
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Dump information from `stacks-node` storage
 
 ## Usage
 
+Run the script using the current working directory for `stacks-node`, generally found in the `/tmp` folder unless specified via the config file.
+
 ### Default
 
 ```
@@ -12,7 +14,7 @@ node report-pox-krypton.js /tmp/stacks-testnet-5c87e24790411516
 
 ### Options
 
-`-t` - display transactions for each block (if `stacks-node) is compiled with `--feature tx-log`
+`-t or --tx-log` - display transactions for each block (if `stacks-node` is compiled with `--feature tx-log`)
 
 ```
 cargo build --workspace  --features tx_log --bin stacks-node
@@ -20,9 +22,8 @@ cargo build --workspace  --features tx_log --bin stacks-node
 node report-pox-krypton.js -t /tmp/stacks-testnet-5c87e24790411516
 ```
 
-`-csv` - display transactions in CSV format
+`-c or --csv` - display transactions in CSV format
 
 ```
-node report-pox-krypton.js -csv /tmp/stacks-testnet-5c87e24790411516
+node report-pox-krypton.js -c /tmp/stacks-testnet-5c87e24790411516
 ```
-

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -310,8 +310,31 @@ const staging_db_path = 'chainstate/chain-00000080-testnet/blocks/staging.db'
 //                                            vtxindex INT NOT NULL
 //     );
 
-const data_root_path = `${root}${process.argv[3] || process.argv[2]}`
-const use_txs = process.argv[2] === '-t'
+// const data_root_path = `${root}${process.argv[3] || process.argv[2]}`
+// const use_txs = process.argv[2] === '-t'
+
+let use_txs = false;
+let use_csv = false;
+var myArgs = process.argv.slice(2);
+// console.log('myArgs: ', myArgs);
+
+for (let j = 0; j < myArgs.length; j++){
+  switch (myArgs[j]) {
+    case '-t':
+      use_txs = true;
+      break;
+    case '-csv':
+      use_csv = true;
+      break;
+    default:
+      if (myArgs[j].startsWith('/tmp')) {
+        var data_root_path = `${root}${myArgs[j]}`;
+      } else {
+        console.log('input not recognized: ', myArgs[j]);
+      }
+      break;
+  }
+}
 
 const burnchain_db = new Database(`${data_root_path}/${burnchain_db_path}`, {
   readonly: true,

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -313,8 +313,8 @@ const staging_db_path = 'chainstate/chain-00000080-testnet/blocks/staging.db'
 // const data_root_path = `${root}${process.argv[3] || process.argv[2]}`
 // const use_txs = process.argv[2] === '-t'
 
-const use_txs = false;
-const use_csv = false;
+let use_txs = false;
+let use_csv = false;
 const my_args = process.argv.slice(2);
 // console.log('my_args: ', my_args);
 

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -792,10 +792,10 @@ function process_burnchain_ops() {
   if (use_csv){
     // display CSV output
     console.log("========================================================================================================================")
-    console.log("STX address,BTC address,actual wins,total wins,total mined,%won,%actual wins,paid satoshis,Th[theoritical win%],avg paid")
+    console.log("STX address,BTC address,actual wins,total wins,total mined,%won,%actual wins,paid satoshis,theoritical win%,avg paid")
     for (let miner_key of Object.keys(miners).sort()) {
       const miner = miners[miner_key]
-      console.log(`${miner_key},${c32.c32ToB58(miner_key)},${miner.actual_win},${miner.won},${miner.mined},${(miner.won / miner.mined * 100).toFixed(2)}%,${(miner.actual_win / actual_win_total * 100).toFixed(2)}%,${miner.burned},Th[${(miner.burned / miner.total_burn * 100).toFixed(2)}%],${miner.burned / miner.mined}`)
+      console.log(`${miner_key},${c32.c32ToB58(miner_key)},${miner.actual_win},${miner.won},${miner.mined},${(miner.won / miner.mined * 100).toFixed(2)}%,${(miner.actual_win / actual_win_total * 100).toFixed(2)}%,${miner.burned},${(miner.burned / miner.total_burn * 100).toFixed(2)}%,${miner.burned / miner.mined}`)
       miner.average_burn = miner.burned / miner.mined
       miner.normalized_wins = miner.won / miner.average_burn
     }

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -321,9 +321,11 @@ const my_args = process.argv.slice(2);
 for (let j = 0; j < my_args.length; j++){
   switch (my_args[j]) {
     case '-t':
+    case '--tx-log':
       use_txs = true;
       break;
-    case '-csv':
+    case '-c':
+    case '--csv':
       use_csv = true;
       break;
     default:

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -337,9 +337,7 @@ for (let j = 0; j < my_args.length; j++) {
       break
   }
 }
-console.log('data root path: ', data_root_path)
-
-process.exit(1)
+// console.log('data root path: ', data_root_path)
 
 const burnchain_db = new Database(`${data_root_path}/${burnchain_db_path}`, {
   readonly: true,

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -315,6 +315,7 @@ const staging_db_path = 'chainstate/chain-00000080-testnet/blocks/staging.db'
 
 let use_txs = false;
 let use_csv = false;
+let data_root_path = '';
 const my_args = process.argv.slice(2);
 // console.log('my_args: ', my_args);
 
@@ -330,7 +331,7 @@ for (let j = 0; j < my_args.length; j++){
       break;
     default:
       if (my_args[j].startsWith('/tmp')) {
-        var data_root_path = `${root}${my_args[j]}`;
+        data_root_path = `${root}${my_args[j]}`;
       } else {
         console.log('input not recognized: ', my_args[j]);
       }

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -319,29 +319,27 @@ let data_root_path = ''
 const my_args = process.argv.slice(2)
 // console.log('my_args: ', my_args);
 
-if (my_args.length > 1) {
-  // iterate through included options
-  for (let j = 0; j < my_args.length; j++) {
-    // console.log(j, ': ', my_args[j])
-    switch (my_args[j]) {
-      case '-t':
-      case '--tx-log':
-        use_txs = true
-        break
-      case '-c':
-      case '--csv':
-        use_csv = true
-        break
-      default:
-        data_root_path = `${root}${my_args[j]}`
-        break
-    }
+// iterate through included options
+for (let j = 0; j < my_args.length; j++) {
+  // console.log(j, ': ', my_args[j])
+  switch (my_args[j]) {
+    case '-t':
+    case '--tx-log':
+      use_txs = true
+      break
+    case '-c':
+    case '--csv':
+      use_csv = true
+      break
+    default:
+      // assuming last argument is root path
+      data_root_path = `${root}${my_args[j]}`
+      break
   }
-} else {
-  // assume only working dir was passed
-  data_root_path = `${root}${my_args[0]}`
 }
-// console.log('data root path: ', data_root_path)
+console.log('data root path: ', data_root_path)
+
+process.exit(1)
 
 const burnchain_db = new Database(`${data_root_path}/${burnchain_db_path}`, {
   readonly: true,

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -313,13 +313,13 @@ const staging_db_path = 'chainstate/chain-00000080-testnet/blocks/staging.db'
 // const data_root_path = `${root}${process.argv[3] || process.argv[2]}`
 // const use_txs = process.argv[2] === '-t'
 
-let use_txs = false;
-let use_csv = false;
-var myArgs = process.argv.slice(2);
-// console.log('myArgs: ', myArgs);
+const use_txs = false;
+const use_csv = false;
+const my_args = process.argv.slice(2);
+// console.log('my_args: ', my_args);
 
-for (let j = 0; j < myArgs.length; j++){
-  switch (myArgs[j]) {
+for (let j = 0; j < my_args.length; j++){
+  switch (my_args[j]) {
     case '-t':
       use_txs = true;
       break;
@@ -327,10 +327,10 @@ for (let j = 0; j < myArgs.length; j++){
       use_csv = true;
       break;
     default:
-      if (myArgs[j].startsWith('/tmp')) {
-        var data_root_path = `${root}${myArgs[j]}`;
+      if (my_args[j].startsWith('/tmp')) {
+        var data_root_path = `${root}${my_args[j]}`;
       } else {
-        console.log('input not recognized: ', myArgs[j]);
+        console.log('input not recognized: ', my_args[j]);
       }
       break;
   }

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -313,11 +313,38 @@ const staging_db_path = 'chainstate/chain-00000080-testnet/blocks/staging.db'
 // const data_root_path = `${root}${process.argv[3] || process.argv[2]}`
 // const use_txs = process.argv[2] === '-t'
 
-let use_txs = false;
-let use_csv = false;
-let data_root_path = '';
-const my_args = process.argv.slice(2);
+let use_txs = false
+let use_csv = false
+let data_root_path = ''
+const my_args = process.argv.slice(2)
 // console.log('my_args: ', my_args);
+
+if (my_args.length > 1) {
+  // iterate through included options
+  for (let j = 0; j < my_args.length; j++) {
+    console.log(j, ': ', my_args[j])
+    switch (my_args[j]) {
+      case '-t':
+      case '--tx-log':
+        use_txs = true
+        break
+      case '-c':
+      case '--csv':
+        use_csv = true
+        break
+      default:
+        data_root_path = `${root}${my_args[j]}`
+        break
+    }
+  }
+} else {
+  // assume only working dir was passed
+  data_root_path = `${root}${my_args[0]}`
+}
+
+console.log('data root path: ', data_root_path)
+
+process.exit(1)
 
 for (let j = 0; j < my_args.length; j++){
   switch (my_args[j]) {

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -783,25 +783,39 @@ function process_burnchain_ops() {
   // }
 
 
+
+
   if (use_txs) {
     console.log("========================================================================================================================")
     console.log("total transactions (excl coinbase)", transaction_count)
   }
-  console.log("========================================================================================================================")
-  console.log("STX address/BTC address - actual wins/total wins/total mined %won %actual wins - paid satoshis Th[theoritical win%] (avg paid)")
-  for (let miner_key of Object.keys(miners).sort()) {
-    const miner = miners[miner_key]
-    console.log(`${miner_key}/${c32.c32ToB58(miner_key)} ${miner.actual_win}/${miner.won}/${miner.mined} ${(miner.won / miner.mined * 100).toFixed(2)}% ${(miner.actual_win / actual_win_total * 100).toFixed(2)}% - ${miner.burned} - Th[${(miner.burned / miner.total_burn * 100).toFixed(2)}%] (${miner.burned / miner.mined})`)
-    miner.average_burn = miner.burned / miner.mined
-    miner.normalized_wins = miner.won / miner.average_burn
-  }
+  if (use_csv){
+    // display CSV output
+    console.log("========================================================================================================================")
+    console.log("STX address,BTC address,actual wins,total wins,total mined,%won,%actual wins,paid satoshis,Th[theoritical win%],avg paid")
+    for (let miner_key of Object.keys(miners).sort()) {
+      const miner = miners[miner_key]
+      console.log(`${miner_key},${c32.c32ToB58(miner_key)},${miner.actual_win},${miner.won},${miner.mined},${(miner.won / miner.mined * 100).toFixed(2)}%,${(miner.actual_win / actual_win_total * 100).toFixed(2)}%,${miner.burned},Th[${(miner.burned / miner.total_burn * 100).toFixed(2)}%],${miner.burned / miner.mined}`)
+      miner.average_burn = miner.burned / miner.mined
+      miner.normalized_wins = miner.won / miner.average_burn
+    }
+  } else {
+    // display console output
+    console.log("========================================================================================================================")
+    console.log("STX address/BTC address - actual wins/total wins/total mined %won %actual wins - paid satoshis Th[theoritical win%] (avg paid)")
+    for (let miner_key of Object.keys(miners).sort()) {
+      const miner = miners[miner_key]
+      console.log(`${miner_key}/${c32.c32ToB58(miner_key)} ${miner.actual_win}/${miner.won}/${miner.mined} ${(miner.won / miner.mined * 100).toFixed(2)}% ${(miner.actual_win / actual_win_total * 100).toFixed(2)}% - ${miner.burned} - Th[${(miner.burned / miner.total_burn * 100).toFixed(2)}%] (${miner.burned / miner.mined})`)
+      miner.average_burn = miner.burned / miner.mined
+      miner.normalized_wins = miner.won / miner.average_burn
+    }
 
-  console.log("========================================================================================================================")
-  for (let miner_key of Object.keys(miners).sort((a, b) => (miners[b].normalized_wins - miners[a].normalized_wins))) {
-    const miner = miners[miner_key]
-    console.log(`${miner_key}/${c32.c32ToB58(miner_key)} ${miner.actual_win}/${miner.won}/${miner.mined} ${(miner.won / miner.mined * 100).toFixed(2)}% ${(miner.actual_win / actual_win_total * 100).toFixed(2)}% - ${miner.burned} - Th[${(miner.burned / miner.total_burn * 100).toFixed(2)}%] (${miner.burned / miner.mined}) ${miner.normalized_wins}`)
+    console.log("========================================================================================================================")
+    for (let miner_key of Object.keys(miners).sort((a, b) => (miners[b].normalized_wins - miners[a].normalized_wins))) {
+      const miner = miners[miner_key]
+      console.log(`${miner_key}/${c32.c32ToB58(miner_key)} ${miner.actual_win}/${miner.won}/${miner.mined} ${(miner.won / miner.mined * 100).toFixed(2)}% ${(miner.actual_win / actual_win_total * 100).toFixed(2)}% - ${miner.burned} - Th[${(miner.burned / miner.total_burn * 100).toFixed(2)}%] (${miner.burned / miner.mined}) ${miner.normalized_wins}`)
+    }
   }
-
 
 })()
 

--- a/report-pox-krypton.js
+++ b/report-pox-krypton.js
@@ -322,7 +322,7 @@ const my_args = process.argv.slice(2)
 if (my_args.length > 1) {
   // iterate through included options
   for (let j = 0; j < my_args.length; j++) {
-    console.log(j, ': ', my_args[j])
+    // console.log(j, ': ', my_args[j])
     switch (my_args[j]) {
       case '-t':
       case '--tx-log':
@@ -341,30 +341,7 @@ if (my_args.length > 1) {
   // assume only working dir was passed
   data_root_path = `${root}${my_args[0]}`
 }
-
-console.log('data root path: ', data_root_path)
-
-process.exit(1)
-
-for (let j = 0; j < my_args.length; j++){
-  switch (my_args[j]) {
-    case '-t':
-    case '--tx-log':
-      use_txs = true;
-      break;
-    case '-c':
-    case '--csv':
-      use_csv = true;
-      break;
-    default:
-      if (my_args[j].startsWith('/tmp')) {
-        data_root_path = `${root}${my_args[j]}`;
-      } else {
-        console.log('input not recognized: ', my_args[j]);
-      }
-      break;
-  }
-}
+// console.log('data root path: ', data_root_path)
 
 const burnchain_db = new Database(`${data_root_path}/${burnchain_db_path}`, {
   readonly: true,


### PR DESCRIPTION
My goal with this PR was to:

1. check the inputs in any order and set variables accordingly
1. display a message if the input is not recognized (i.e. `-wtf`)
1. update console logging output depending on `use_csv` variable

For the CSV output I took the `Th[ ]` off the theoretical win column so it would sort correctly. If i left it as-is, `Th[3%]` sorts right next to `Th[33%]`.

Sample command:

`node report-pox-krypton.js -wtf -csv /tmp/stacks-testnet-0190272ea1a9cda2/`

Works the same as:

`node report-pox-krypton.js /tmp/stacks-testnet-0190272ea1a9cda2/ -wtf -csv`

Sample output:

![20201028_001_Selection](https://user-images.githubusercontent.com/9038904/97452293-d1bde480-18f1-11eb-9845-1d4e37f0ef59.png)

Copied into spreadsheet:

![20201028_002_Selection](https://user-images.githubusercontent.com/9038904/97452313-d5ea0200-18f1-11eb-8832-c2d7a210fbc4.png)

![20201028_003_Selection](https://user-images.githubusercontent.com/9038904/97452323-d84c5c00-18f1-11eb-9a90-f1cef111fe6e.png)