### PR TITLE
Use correct db file for staging database

### DIFF
--- a/report.js
+++ b/report.js
@@ -343,8 +343,7 @@ for (let j = 0; j < my_args.length; j++) {
 const burnchain_db_path = `burnchain/db/bitcoin/${target === 'xenon' ? 'testnet' : 'regtest'}/burnchain.db`
 const sortition_db_path = `burnchain/db/bitcoin/${target === 'xenon' ? 'testnet' : 'regtest'}/sortition.db/marf`
 const vm_db_path = "chainstate/chain-00000080-testnet/vm/index"
-const staging_db_path = 'chainstate/chain-00000080-testnet/blocks/staging.db'
-
+const staging_db_path = "chainstate/chain-00000080-testnet/vm/index";
 
 const burnchain_db = new Database(`${data_root_path}/${burnchain_db_path}`, {
   readonly: true,


### PR DESCRIPTION
This PR
* makes changes required for stacks-node 24.1.+
* changes the database file that contains the staging table to "chainstate/chain-00000080-testnet/vm/index"
* fixes #6 
