### PR TITLE
Update outputs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ node report -d /tmp/stacks-testnet-5c87e24790411516
 
 #### End block
 
-`-e BURN_BLOCK_HEIGHT` or `--end-block BURN_BLOCK_HEIGHT`
-Rather than dump all blocks, will stop at BURN_BLOCK_HEIGHT - 1
+`-e BURN_BLOCK_HEIGHT` or `--end-block BURN_BLOCK_HEIGHT` - rather than dump all blocks, will stop at `BURN_BLOCK_HEIGHT - 1`
+
+```bash
+node report -e 667300 /tmp/stacks-testnet-5c87e24790411516
+```
 
 #### Skip output of totals
 
@@ -104,9 +107,11 @@ node report -g /tmp/stacks-testnet-5c87e24790411516
 
 #### Start block
 
-`-s BURN_BLOCK_HEIGHT` or `--start-block BURN_BLOCK_HEIGHT`
+`-s BURN_BLOCK_HEIGHT` or `--start-block BURN_BLOCK_HEIGHT` - rather than dump all blocks, will start at `BURN_BLOCK_HEIGHT`
 
-Rather than dump all blocks, will start at BURN_BLOCK_HEIGHT
+```bash
+node report -s 665250 /tmp/stacks-testnet-5c87e24790411516
+```
 
 #### Show transactions
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ To use, make sure that the stacks data directory is mounted into the container:
 docker run -v /tmp/stacks-testnet-5c87e24790411516:/data -ti stacks-dump:latest /data
 ```
 
-
 ## Usage
 
 Run the script using the current working directory for `stacks-node`, generally found in the `/tmp` folder unless specified via the config file.
@@ -46,11 +45,15 @@ In the commands below, an example folder of `/tmp/stacks-testnet-5c87e2479041151
 
 ### Default
 
+By default, the output will contain the block details, miner statistics, and total statistics.
+
 ```bash
 node report /tmp/stacks-testnet-5c87e24790411516
 ```
 
 ### Options
+
+There are several options to modify the behavior and output of stacks-dump, and multiple options can be combined depending on your use case.
 
 #### Output stats sorted alpha
 
@@ -60,13 +63,19 @@ node report /tmp/stacks-testnet-5c87e24790411516
 node report -a /tmp/stacks-testnet-5c87e24790411516
 ```
 
-#### Output stats as CSV
+#### Skip output of block data
 
-`-c` or `--csv` - display transactions in CSV format
+`-b` or `--no-blocks` - do not display individual block data
+
+#### Output stats in CSV format
+
+`-c` or `--csv` - display miner statistics in CSV format
 
 ```bash
 node report -c /tmp/stacks-testnet-5c87e24790411516
 ```
+
+*Note: only shows miner statistics, implies `-b` and `-g`*
 
 #### Output block commit distances
 
@@ -80,6 +89,10 @@ node report -d /tmp/stacks-testnet-5c87e24790411516
 
 `-e BURN_BLOCK_HEIGHT` or `--end-block BURN_BLOCK_HEIGHT`
 Rather than dump all blocks, will stop at BURN_BLOCK_HEIGHT - 1
+
+#### Skip output of totals
+
+`-g` or `--no-totals` - do not display total statistics
 
 #### Start block
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ node report -a /tmp/stacks-testnet-5c87e24790411516
 
 `-b` or `--no-blocks` - do not display individual block data
 
+```bash
+node report -b /tmp/stacks-testnet-5c87e24790411516
+```
+
 #### Output stats in CSV format
 
 `-c` or `--csv` - display miner statistics in CSV format
@@ -93,6 +97,10 @@ Rather than dump all blocks, will stop at BURN_BLOCK_HEIGHT - 1
 #### Skip output of totals
 
 `-g` or `--no-totals` - do not display total statistics
+
+```bash
+node report -g /tmp/stacks-testnet-5c87e24790411516
+```
 
 #### Start block
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ node report -e 667300 /tmp/stacks-testnet-5c87e24790411516
 node report -g /tmp/stacks-testnet-5c87e24790411516
 ```
 
+#### Dump `krypton` instead of `mainnet`
+
+`-k` or `--krypton` - the internal structure for `krypton` requires this option
+
+```bash
+node report -k /tmp/stacks-testnet-5c87e24790411516
+```
+
+#### Dump `mainnet` data, now the default if not included
+
+`-m` or `--mainnet` - the internal structure for `mainnet` requires this option
+
+```bash
+node report -m /tmp/stacks-testnet-5c87e24790411516
+```
+
+#### List all known stacks-nodes
+
+`-n` or `--nodes` - display list of nodes
+
+```bash
+node report -n /tmp/stacks-testnet-5c87e24790411516
+```
+
 #### Start block
 
 `-s BURN_BLOCK_HEIGHT` or `--start-block BURN_BLOCK_HEIGHT` - rather than dump all blocks, will start at `BURN_BLOCK_HEIGHT`
@@ -123,36 +147,12 @@ cargo build --workspace  --features tx_log --bin stacks-node
 node report -t /tmp/stacks-testnet-5c87e24790411516
 ```
 
-#### Dump `krypton` instead of `mainnet`
-
-`-k` or `--krypton` - the internal structure for `krypton` requires this option
-
-```bash
-node report -k /tmp/stacks-testnet-5c87e24790411516
-```
-
-#### Dump `mainnet` data, now the default if not included
-
-`-m` or `--mainnet` - the internal structure for `mainnet` requires this option
-
-```bash
-node report -m /tmp/stacks-testnet-5c87e24790411516
-```
-
 #### Dump `xenon` instead of `mainnet`
 
 `-x` or `--xenon` - the internal structure for `xenon` requires this option
 
 ```bash
 node report -x /tmp/stacks-testnet-5c87e24790411516
-```
-
-#### List all known stacks-nodes
-
-`-n` or `--nodes` - display list of nodes
-
-```bash
-node report -n /tmp/stacks-testnet-5c87e24790411516
 ```
 
 ## Block information

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ node report -g /tmp/stacks-testnet-5c87e24790411516
 node report -k /tmp/stacks-testnet-5c87e24790411516
 ```
 
+#### Skip output of stacks-dump logo
+
+`-l` or `--no-logo` - do not display the stacks-dump logo
+
+```bash
+node report -l /tmp/stacks-testnet-5c87e24790411516
+```
+
 #### Dump `mainnet` data, now the default if not included
 
 `-m` or `--mainnet` - the internal structure for `mainnet` requires this option
@@ -127,6 +135,30 @@ node report -m /tmp/stacks-testnet-5c87e24790411516
 
 ```bash
 node report -n /tmp/stacks-testnet-5c87e24790411516
+```
+
+#### Dump `mocknet` instead of `mainnet`
+
+`-o` or `--mocknet` - the internal structure for `mocknet` requires this option
+
+```bash
+node report -o /tmp/stacks-testnet-5c87e24790411516
+```
+
+#### Show paths
+
+`-p` or `--show-paths` - show the paths to the burnchain, sortition, vm, and staging databases
+
+```bash
+node report -p /tmp/stacks-testnet-5c87e24790411516
+```
+
+#### Show leader key registrations
+
+`-r` or `--key-registration` - show leader key registrations
+
+```bash
+node report -r /tmp/stacks-testnet-5c87e24790411516
 ```
 
 #### Start block

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Image of Yaktocat](https://github.com/psq/stacks-dump/raw/master/stacks-dump-truck-dark.png)
-
 # stacks-dump
+
+![Stacks Dump Logo](https://github.com/psq/stacks-dump/raw/master/stacks-dump-truck-dark.png)
 
 Dump information from `stacks-node` storage for the [Stacks blockchain](https://github.com/blockstack/stacks-blockchain).
 

--- a/report.js
+++ b/report.js
@@ -1168,6 +1168,20 @@ function process_burnchain_ops() {
           console.log(`${miner_key}/${c32.c32ToB58(miner_key)} ${adjustSpace(miner_key)} ${miner.average_distance.toFixed(2)}  <${!isNaN(miner.next_average_distance) ? miner.next_average_distance.toFixed(2) : '----'}> ${miner.actual_win}/${miner.won}/${miner.mined} ${(miner.actual_win / actual_win_total * 100).toFixed(2)}% ${(miner.won / miner.mined * 100).toFixed(2)}% - ${numberWithCommas(miner.burned, 0)} - Th[${(miner.burned / miner.total_burn * 100).toFixed(2)}%] (${miner.burned / miner.mined}) ${miner.normalized_wins}`)          
         }
       }
+      console.log("block_parent_distances")
+      for (let index = 0; index < block_parent_distances.length; index++) {
+        const block_parent_distance = block_parent_distances[index]
+        if (block_parent_distance) {
+          console.log(`${index} ${block_parent_distance} ${(block_parent_distance / block_parent_distance_count * 100).toFixed(2)}%`)
+        }
+      }
+      console.log("block_commits_parent_distances")
+      for (let index = 0; index < block_commits_parent_distances.length; index++) {
+        const block_commits_parent_distance = block_commits_parent_distances[index]
+        if (block_commits_parent_distance) {
+          console.log(`${index} ${block_commits_parent_distance} ${(block_commits_parent_distance / block_commits_parent_distance_count * 100).toFixed(2)}%`)
+        }
+      } 
     }
     if (show_totals) {
       console.log("Statistics ========================================================================================================================")
@@ -1182,22 +1196,6 @@ function process_burnchain_ops() {
       console.log("incorrect blocks:", incorrect_blocks)
       if (use_txs) {
         console.log("total transactions (excl coinbase)", transaction_count)
-      }
-      if (show_distances) {
-        console.log("block_parent_distances")
-        for (let index = 0; index < block_parent_distances.length; index++) {
-          const block_parent_distance = block_parent_distances[index]
-          if (block_parent_distance) {
-            console.log(`${index} ${block_parent_distance} ${(block_parent_distance / block_parent_distance_count * 100).toFixed(2)}%`)
-          }
-        }
-        console.log("block_commits_parent_distances")
-        for (let index = 0; index < block_commits_parent_distances.length; index++) {
-          const block_commits_parent_distance = block_commits_parent_distances[index]
-          if (block_commits_parent_distance) {
-            console.log(`${index} ${block_commits_parent_distance} ${(block_commits_parent_distance / block_commits_parent_distance_count * 100).toFixed(2)}%`)
-          }
-        }      
       }
     }
   }

--- a/report.js
+++ b/report.js
@@ -377,13 +377,13 @@ const root = ''
 // const use_txs = process.argv[2] === '-t'
 
 let target = 'mainnet'
-let use_txs = false
-let use_csv = false
 let use_alpha = false
+let use_csv = false
+let use_txs = false
+let show_distances = false
+let show_logo = true
 let show_nodes = false
 let show_paths = false
-let show_logo = true
-let show_distances = false
 let show_registrations = false
 let start_block = 0
 let end_block = 2000000000 // probably high enough

--- a/report.js
+++ b/report.js
@@ -380,11 +380,13 @@ let target = 'mainnet'
 let use_alpha = false
 let use_csv = false
 let use_txs = false
+let show_blocks = true
 let show_distances = false
 let show_logo = true
 let show_nodes = false
 let show_paths = false
 let show_registrations = false
+let show_totals = true
 let start_block = 0
 let end_block = 2000000000 // probably high enough
 let data_root_path = ''
@@ -398,6 +400,10 @@ for (let j = 0; j < my_args.length; j++) {
     case '--alpha':
       use_alpha = true
       break
+    case '-b':
+    case '--no-blocks':
+      show_blocks = false
+      break
     case '-c':
     case '--csv':
       use_csv = true
@@ -410,6 +416,10 @@ for (let j = 0; j < my_args.length; j++) {
     case '-e':
       j++
       end_block = parseInt(my_args[j])
+      break
+    case '-g':
+    case '--no-totals':
+      show_totals = false
       break
     case '-k':
     case '--krypton':
@@ -906,7 +916,9 @@ function process_burnchain_ops() {
     }
     burnchain_ops_by_burn_hash[row.block_hash].push(op)
   }
-  !use_csv && console.log("Blocks ============================================================================================================================")
+  if (!use_csv && show_blocks) {
+    console.log("Blocks ============================================================================================================================")
+  }
 }
 
 
@@ -987,27 +999,29 @@ function process_burnchain_ops() {
 
     
     // console.log("current_winner_block", current_winner_block)
-    !use_csv && console.log(
-      block.block_height,
-      current_winner_block ? block_parent_distance : '?',
-      current_winner_block && current_winner_block.parent_block_ptr ? current_winner_block.parent_block_ptr : '   -  ',
+    if (!use_csv && show_blocks) {
+      console.log(
+        block.block_height,
+        current_winner_block ? block_parent_distance : '?',
+        current_winner_block && current_winner_block.parent_block_ptr ? current_winner_block.parent_block_ptr : '   -  ',
 
-      // block.block_headers.length ? `${block.block_headers[0].block_height}` : '-',
-      block.payments.length ? `${block.payments[0].stacks_block_height}${at_tip}` : '     ',
-      block.payments.length ? `${numberWithCommas(parseInt(block.payments[0].coinbase) / 1000000, 2)}` : '   -    ',
-      block.actual_burn !== 0 ? numberWithCommas(block.actual_burn, 0) : '    -    ',
-      block.branch_info ? `${fixedBranchName(block.branch_info.name)}` : '    ',
-      // block.branch_info ? block.branch_info.height_created : '-',
-      block.block_headers.length ? `s:${block.block_headers[0].block_hash.substring(0, 10)}` : '     -      ',
-      block.block_headers.length ? `p:${block.block_headers[0].parent_block.substring(0, 10)}` : '     -      ',
-      block.block_headers.length ? `c:${block.block_headers[0].consensus_hash.substring(0, 10)}` : '     -      ',
-      stacks_block_id !== '-' ? `i:${stacks_block_id.substring(0, 10)}` : '     -      ',
-      block.block_headers.length ? `b:${block.block_headers[0].burn_header_hash.substring(0, 25)}` : '            -               ',
+        // block.block_headers.length ? `${block.block_headers[0].block_height}` : '-',
+        block.payments.length ? `${block.payments[0].stacks_block_height}${at_tip}` : '     ',
+        block.payments.length ? `${numberWithCommas(parseInt(block.payments[0].coinbase) / 1000000, 2)}` : '   -    ',
+        block.actual_burn !== 0 ? numberWithCommas(block.actual_burn, 0) : '    -    ',
+        block.branch_info ? `${fixedBranchName(block.branch_info.name)}` : '    ',
+        // block.branch_info ? block.branch_info.height_created : '-',
+        block.block_headers.length ? `s:${block.block_headers[0].block_hash.substring(0, 10)}` : '     -      ',
+        block.block_headers.length ? `p:${block.block_headers[0].parent_block.substring(0, 10)}` : '     -      ',
+        block.block_headers.length ? `c:${block.block_headers[0].consensus_hash.substring(0, 10)}` : '     -      ',
+        stacks_block_id !== '-' ? `i:${stacks_block_id.substring(0, 10)}` : '     -      ',
+        block.block_headers.length ? `b:${block.block_headers[0].burn_header_hash.substring(0, 25)}` : '            -               ',
 
-      block.block_headers.length ? `${block.block_headers[0].parent_block === parent_hash ? ((parent_winner_block ? parent_winner_block.leader_key_address : null) === (current_winner_block ? current_winner_block.leader_key_address : null) ? '@+' : '@@') : '  '}` : '  ',
-      txids,
-      block.block_commits.sort((a, b) => (a.leader_key_address.localeCompare(b.leader_key_address))).map(bc => `[${(parseInt(bc.burn_fee) / block_burn * 100).toFixed(1)}]${bc.txid === block.winning_block_txid ? (chalk.green(bc.leader_key_address.substring(0, 10) + '*')) : (bc.leader_key_address.substring(0, 10) + ' ')}`).join(''),
-    )
+        block.block_headers.length ? `${block.block_headers[0].parent_block === parent_hash ? ((parent_winner_block ? parent_winner_block.leader_key_address : null) === (current_winner_block ? current_winner_block.leader_key_address : null) ? '@+' : '@@') : '  '}` : '  ',
+        txids,
+        block.block_commits.sort((a, b) => (a.leader_key_address.localeCompare(b.leader_key_address))).map(bc => `[${(parseInt(bc.burn_fee) / block_burn * 100).toFixed(1)}]${bc.txid === block.winning_block_txid ? (chalk.green(bc.leader_key_address.substring(0, 10) + '*')) : (bc.leader_key_address.substring(0, 10) + ' ')}`).join(''),
+      )
+    }
     // console.log(block.payments)
     miner_count_last_block = block.block_commits.length
     burn_last_block = block.actual_burn // block.payments.length ? block.payments[0].burnchain_sortition_burn : 0
@@ -1155,36 +1169,37 @@ function process_burnchain_ops() {
         }
       }
     }
-    console.log("Statistics ========================================================================================================================")
-    console.log("miners (last block):", miner_count_last_block)
-    console.log("miners (overall):", Object.keys(miners).length)
-    console.log("total commit (last block):", numberWithCommas(burn_last_block, 0), "sats")
-    console.log("block reward (last block):", numberWithCommas(reward_last_block, 2), "STX")
-    console.log("btc blocks:", blocks)
-    console.log("empty btc blocks:", empty_blocks)
-    console.log("actual_win_total:", actual_win_total)
-    console.log("orphaned blocks:", blocks - empty_blocks - actual_win_total - incorrect_blocks)
-    console.log("incorrect blocks:", incorrect_blocks)
-    if (use_txs) {
-      console.log("total transactions (excl coinbase)", transaction_count)
-    }
-    if (show_distances) {
-      console.log("block_parent_distances")
-      for (let index = 0; index < block_parent_distances.length; index++) {
-        const block_parent_distance = block_parent_distances[index]
-        if (block_parent_distance) {
-          console.log(`${index} ${block_parent_distance} ${(block_parent_distance / block_parent_distance_count * 100).toFixed(2)}%`)
-        }
+    if (show_totals) {
+      console.log("Statistics ========================================================================================================================")
+      console.log("miners (last block):", miner_count_last_block)
+      console.log("miners (overall):", Object.keys(miners).length)
+      console.log("total commit (last block):", numberWithCommas(burn_last_block, 0), "sats")
+      console.log("block reward (last block):", numberWithCommas(reward_last_block, 2), "STX")
+      console.log("btc blocks:", blocks)
+      console.log("empty btc blocks:", empty_blocks)
+      console.log("actual_win_total:", actual_win_total)
+      console.log("orphaned blocks:", blocks - empty_blocks - actual_win_total - incorrect_blocks)
+      console.log("incorrect blocks:", incorrect_blocks)
+      if (use_txs) {
+        console.log("total transactions (excl coinbase)", transaction_count)
       }
-      console.log("block_commits_parent_distances")
-      for (let index = 0; index < block_commits_parent_distances.length; index++) {
-        const block_commits_parent_distance = block_commits_parent_distances[index]
-        if (block_commits_parent_distance) {
-          console.log(`${index} ${block_commits_parent_distance} ${(block_commits_parent_distance / block_commits_parent_distance_count * 100).toFixed(2)}%`)
+      if (show_distances) {
+        console.log("block_parent_distances")
+        for (let index = 0; index < block_parent_distances.length; index++) {
+          const block_parent_distance = block_parent_distances[index]
+          if (block_parent_distance) {
+            console.log(`${index} ${block_parent_distance} ${(block_parent_distance / block_parent_distance_count * 100).toFixed(2)}%`)
+          }
         }
-      }      
+        console.log("block_commits_parent_distances")
+        for (let index = 0; index < block_commits_parent_distances.length; index++) {
+          const block_commits_parent_distance = block_commits_parent_distances[index]
+          if (block_commits_parent_distance) {
+            console.log(`${index} ${block_commits_parent_distance} ${(block_commits_parent_distance / block_commits_parent_distance_count * 100).toFixed(2)}%`)
+          }
+        }      
+      }
     }
-
   }
 
 })()


### PR DESCRIPTION
This PR adds two new options to fix #17 as well as cleans up the readme a bit.

One thought I had while drafting this - do we really need an example *per option* or would it be easier to give some examples following the options? I think this would make the readme easier to read, e.g. below.

### Examples

The options above can be combined to achieve the desired result.

Example 1: output only miner statistics in CSV format for mainnet data

```bash
node report -c /tmp/stacks-testnet-5c87e24790411516
```

Example 2: output block data, miner statistics sorted alpha, and statistics for xenon data

```bash
node report -a -x /tmp/stacks-testnet-5c87e24790411516
```

Example 3: skip output of block data, output miner statistics sorted alpha, block distances, and transactions for mainnet data, between btc blocks 665250 and 667300

```bash
node report -a -b -d -s 665250 -e 667300 /tmp/stacks-testnet-5c87e24790411516
```

Example 4: long form names are interchangeable with the single letter options

```bash
node report --alpha --no-blocks --distances -s 665250 -e 667300 /tmp/stacks-testnet-5c87e24790411516
```